### PR TITLE
ci: add native aarch64 Linux to CI and release validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,20 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  aarch64:
+    name: aarch64 Linux (native)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check (default features)
+        run: cargo check
+      - name: Check (all features)
+        run: cargo check --all-features
+      - name: Test
+        run: cargo test --all-features
+
   msrv:
     name: MSRV (1.75)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Motivation

`raibid-harness` (incoming DGX-Spark-native harness for coding agents)
targets `aarch64-unknown-linux-gnu` as its primary triple.
`fusabi-plugin-runtime` is the crate `harness-skills` uses to load and
hot-reload `.fsx` plugins. Today CI runs only on x86_64, so aarch64
breakage can ship to crates.io unnoticed.

See survey: `/tmp/fusabi-aarch64-survey.md`.

## What changed

**`.github/workflows/ci.yml`**
- New `aarch64` job on `ubuntu-24.04-arm`. Runs `cargo check`,
  `cargo check --all-features`, and `cargo test --all-features`.

**`.github/workflows/release.yml`**
- Added `ubuntu-24.04-arm` to the `build` matrix so a broken aarch64
  build blocks `cargo publish`.

No binary artifact production — library crate, source-only on crates.io.

## Test plan

- [ ] New `aarch64 Linux (native)` CI job passes on this PR.
- [ ] Dispatch `Release` with a pre-release tag and confirm the new
      `ubuntu-24.04-arm` matrix leg succeeds.

## Known gaps

- Features `serde`, `watch` — pure Rust, no native-dep risk. If the
  new job exposes a problem, follow-up PR will handle it.

## Status

**Draft** — ready-for-review after a green aarch64 run.